### PR TITLE
Fix: ModuleNotFoundError

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,7 +12,7 @@ def Run_Button(file):
     output_name = "Log_XMLs/" + os.path.basename(file)
     output_name = os.path.splitext(output_name)[0] + '.xml'
     f = open(output_name, "w", encoding = "utf-8")
-    stout = subprocess.check_output(['python', dumppath, file])
+    stout = subprocess.check_output(['python', dumppath, file], shell=True)
     stout = stout.decode('utf-8')
     f.write(stout)
     f.close()

--- a/app.py
+++ b/app.py
@@ -9,7 +9,7 @@ from pc_variables import browser_path_in_my_pc, url_path_for_browser
 
 def Run_Button(file):
     dumppath = "evtx_dump.py"
-    output_name = "Log_XMLs/" + os.path.basename(file)
+    output_name = os.path.join("Log_XMLs", os.path.basename(file))
     output_name = os.path.splitext(output_name)[0] + '.xml'
     f = open(output_name, "w", encoding = "utf-8")
     stout = subprocess.check_output(['python', dumppath, file], shell=True)
@@ -22,7 +22,7 @@ def Run_Button(file):
 def open_xml(xmlfile):
     # Add browser location from the C drive below:
     browser_location = browser_path_in_my_pc
-    pathadd = url_path_for_browser + xmlfile
+    pathadd = os.path.join(url_path_for_browser, xmlfile)
     webbrowser.get(browser_location).open(pathadd)
 
 


### PR DESCRIPTION
### Changes made:

In `Run_Button(file)`
```diff
- stout = subprocess.check_output(['python', dumppath, file])
+ stout = subprocess.check_output(['python', dumppath, file], shell=True)
```

> If shell is True, the specified command will be executed through the shell.

This makes it possible for the subprocess module to find the installed modules like evtx in the virtualenv. ([python docs](https://docs.python.org/3/library/subprocess.html#frequently-used-arguments))

Also refactored path joins
```diff
-    output_name = "Log_XMLs/" + os.path.basename(file)
+    output_name = os.path.join("Log_XMLs", os.path.basename(file))
-    pathadd = url_path_for_browser + xmlfile
+    pathadd = os.path.join(url_path_for_browser, xmlfile)
```